### PR TITLE
commented lines accidentally left from development

### DIFF
--- a/SelphiFirstDraft-impute_all_chr.py
+++ b/SelphiFirstDraft-impute_all_chr.py
@@ -269,10 +269,10 @@ def selphi(
 
     assert len(samples_segments) == cores > 0, f"got {len(samples_segments)=} and {cores=}"
 
+    # # If you don't want selphi to run for all input samples in the vcf.gz file,
+    # #  then uncomment these lines to rewrite what samples each core should impute
     # samples_segments = [[12],[13],[14],[15],[16],[17],[18],[19],[20],[21]]
     # cores = 10
-    samples_segments = [[12]]
-    cores = 1
 
 
     total_samples_to_impute = sum([len(seg) for seg in samples_segments])


### PR DESCRIPTION
i used to use those 2 lines (273-274) to rewrite what cores should impute what samples. Normally (and after this correction) samples are distributed between cores evenly automatically