### PR TITLE
fix: best haps equal matches

### DIFF
--- a/modules/hmm_utils.py
+++ b/modules/hmm_utils.py
@@ -175,7 +175,7 @@ def setBwdValues_SPARSE(
 
         for fbi in range(forward_decomp_block.shape[0] - 1, -1, -1):
             temp_array = forward_decomp_block[fbi, :].copy()
-            temp_array[temp_array < 1 / matches.size] = 0
+            temp_array[temp_array < 1 / (matches.size + 1)] = 0
             weight_matrix[aci + fbi, matches] = temp_array.copy()
 
     # Run Last iteration
@@ -203,7 +203,7 @@ def setBwdValues_SPARSE(
 
         # put values in the sparse matrix on the fly
         temp_array = forward_decomp_block[aci, :].copy()
-        temp_array[temp_array < 1 / matches.size] = 0
+        temp_array[temp_array < 1 / (matches.size + 1)] = 0
         weight_matrix[aci + 1, matches] = temp_array.copy()
 
     return weight_matrix.tocsr()

--- a/modules/imputation_lib.py
+++ b/modules/imputation_lib.py
@@ -191,7 +191,7 @@ def calculate_weights(
     ).haplotype_id_lists()
 
     haps, counts = np.unique(np.hstack(ordered_hap_indices), return_counts=True)
-    cutoff = np.percentile(counts, 10)
+    cutoff = min(np.percentile(counts, 10), counts.max() - 1)
     best_haps = haps[counts > cutoff]
 
     weight_matrix = run_hmm(


### PR DESCRIPTION
Prevent bug that occurs when best haplotypes are all equally matched to the target haplotype