### PR TITLE
fix: ref/alt dtype len

### DIFF
--- a/modules/sparse_ref_panel.py
+++ b/modules/sparse_ref_panel.py
@@ -322,8 +322,8 @@ class SparseReferencePanel:
         variant_dtypes = [
             ("chr", f"<U{len(str(chrom))}"),
             ("pos", "int"),
-            ("ref", "<U8"),
-            ("alt", "<U8"),
+            ("ref", "<U21"),
+            ("alt", "<U21"),
         ]
         self.variant_dtypes = np.dtype(variant_dtypes)
 

--- a/modules/sparse_ref_panel.py
+++ b/modules/sparse_ref_panel.py
@@ -322,8 +322,8 @@ class SparseReferencePanel:
         variant_dtypes = [
             ("chr", f"<U{len(str(chrom))}"),
             ("pos", "int"),
-            ("ref", "<U21"),
-            ("alt", "<U21"),
+            ("ref", "<U42"),
+            ("alt", "<U42"),
         ]
         self.variant_dtypes = np.dtype(variant_dtypes)
 


### PR DESCRIPTION
Variants were getting removed because the dtypes set when the srp was created were not being used