### PR TITLE
chore: pin numpy 1.26.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ cachetools
 cyvcf2==0.31.1
 joblib
 numba
-numpy
+numpy==1.26.4
 pandas
 scipy
 tqdm


### PR DESCRIPTION
Pin numpy until further testing of numpy 2.0