### PR TITLE
feat: reduced hmm memory usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,51 +1,45 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install required software and clean as not to make the layer dirty
 RUN apt-get update && apt-get -y upgrade && apt-get install -y \
     apt-utils curl gnupg gcc g++ make autoconf git zlib1g-dev libbz2-dev \
-    liblzma-dev libzip-dev libcurl4-openssl-dev bcftools tabix && \
+    liblzma-dev libzip-dev libcurl4-openssl-dev build-essential checkinstall && \
     apt-get clean && apt-get purge && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-# Install python and pip
-RUN apt update
-RUN apt install -y build-essential checkinstall
-RUN apt-get install -y software-properties-common && add-apt-repository ppa:deadsnakes/ppa -y
-RUN apt-get install -y python3.8 python3.8-distutils python3.8-dev && \
-    curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3.8 get-pip.py
+# Install latest bcftools and htslib
+RUN mkdir -p /usr/src/ && cd /usr/src/ && \
+    git clone --recurse-submodules https://github.com/samtools/htslib.git && \
+    git clone https://github.com/samtools/bcftools.git && \
+    cd bcftools && autoheader && autoconf && ./configure && make && make install && \
+    cd /usr/src/htslib && autoreconf -i && ./configure --prefix=/usr/local && \
+    make && make install && rm -fr /usr/src/bcftools /tmp/* /var/tmp/*
 
-# Clone xSqueezeIt and pbwt repositories and build
-RUN mkdir -p /usr/src/ && \
-    cd /usr/src/ && \
+# Clone xSqueezeIt and build if using xsi reference panel files
+RUN cd /usr/src/ && \
     git clone https://github.com/rwk-unil/xSqueezeIt.git && \
     cd /usr/src/xSqueezeIt && \
     git submodule update --init --recursive htslib && \
-    cd htslib && \
-    autoheader && \
-    autoconf && \
-    automake --add-missing 2>/dev/null ; \
-    ./configure && \
-    make && \
-    make install && \
-    ldconfig && \
-    cd .. && \
+    cd htslib && autoheader && autoconf && \
+    automake --add-missing 2>/dev/null ; ./configure && \
+    make && make install && ldconfig && cd .. && \
     git clone https://github.com/facebook/zstd.git && \
-    cd zstd && \
-    make && \
-    cd .. && \
-    make && \
-    chmod +x xsqueezeit && \
-    cp xsqueezeit /usr/local/bin/
+    cd zstd && make && cd .. && make && chmod +x xsqueezeit && \
+    cp xsqueezeit /usr/local/bin/ && \
+    rm -fr /usr/src/xSqueezeIt /tmp/* /var/tmp/*
+
 # Build pbwt library
 RUN mkdir -p /tool
 COPY ./pbwt /tool/pbwt
-RUN cd /tool/pbwt && HTSDIR=/usr/src/xSqueezeIt/htslib make
-# clean up
-RUN rm -r /usr/src/xSqueezeIt
+RUN cd /tool/pbwt && HTSDIR=/usr/src/htslib make
 
-RUN apt install -y  libssl-dev
+# Install python3.10 and pip
+RUN apt update
+RUN apt-get install -y software-properties-common && add-apt-repository ppa:deadsnakes/ppa -y
+RUN apt-get install -y python3 python3-distutils python3-dev python3-pip
+# Install requirements
 COPY requirements.txt requirements.txt
 RUN python3 -m pip install -r requirements.txt
 

--- a/modules/imputation_lib.py
+++ b/modules/imputation_lib.py
@@ -1,13 +1,12 @@
-from typing import List, Tuple
+from typing import Iterable, List, Tuple
 from pathlib import Path
 from logging import Logger
 
 from scipy import sparse
 import numpy as np
 
-from modules.hmm_utils import pRecomb, setFwdValues_SPARSE, setBwdValues_SPARSE
-from modules.load_data import load_sparse_comp_matches_hybrid_npz
-from modules.utils import get_std
+from modules.hmm_utils import HMM
+from modules.load_data import SparseCompositeMatchesNpz
 
 
 def _filter_hap_indices(row_haps: np.ndarray, kept_haps: np.ndarray) -> np.ndarray:
@@ -40,74 +39,29 @@ class CompositePanelMaskFilter:
         self.logger = logger
         self.kept_matches = kept_matches
 
-    def _haps_freqs_array_norm(
-        self, matches_row: sparse.csr_matrix, tmin: float = 0.1, tmax: float = 1
-    ) -> sparse.csc_matrix:
-        """
-        First, calculates what is the number of matches for each chip variant in
-            the new composite ref panel
-        Second, normalizes the results linearly between `tmin` and `tmax`,
-            yielding a useful multiplicative coefficient which scale down ref haploids
-            that have less total matches with the test sample
-        """
-        if not 0 <= tmin < tmax <= 1:
-            raise ValueError(
-                "tmin and tmax parameters must be between 0 and 1, "
-                "and tmax has to be greater than tmin"
-            )
-        freqs: np.ndarray = matches_row.getnnz(axis=1)
-        rmin: int = freqs.min()
-        rmax: int = freqs.max()
-        return sparse.csr_matrix(
-            ((freqs - rmin) / (rmax - rmin)) * (tmax - tmin) + tmin
-        ).transpose()
-
-    def _normalize_matches(self, matches_row: sparse.csr_matrix) -> sparse.csc_matrix:
-        """Multiply matches by normalized haplotype frequencies"""
-        return matches_row.multiply(self._haps_freqs_array_norm(matches_row)).tocsc()
-
-    def _thresh(
-        self, matches_row: sparse.csr_matrix, X: sparse.csc_matrix
-    ) -> np.ndarray:
-        averages = matches_row.sum(axis=0) / matches_row.getnnz(axis=0)
-        std_thresh: np.ndarray = get_std(
-            np.array(averages)[0], matches_row.data.min(), self.shape[1]
-        )
-        std_ = np.array([np.std(X.getcol(index).data) for index in range(X.shape[1])])
-        return np.array(X.max(axis=0) - std_thresh * std_)[0]
-
-    def _best_matches(self, matches_row: sparse.csr_matrix) -> List[np.ndarray]:
-        """Generate all best matches at all variants"""
-        normalized = self._normalize_matches(matches_row)
-        thresh = self._thresh(matches_row, normalized)
-        return [
-            row.indices[
-                np.argsort(row.data)[::-1][
-                    : min(self.kept_matches, (row.data >= thresh[idx]).sum())
-                ]
-            ].copy()
-            for idx, row in enumerate(normalized.transpose())
-        ]
-
+    @staticmethod
     def _expand_matches(
-        self, row, keep: np.ndarray, hap: int, counts: np.ndarray
+        matches: Iterable[Tuple[int]], keep: np.ndarray, hap: int, counts: np.ndarray
     ) -> np.ndarray:
         """Get variants to keep for a haplotype"""
         var_inds = np.hstack(
             [
-                run
-                for run in np.split(row, np.where(np.diff(row) != 1)[0] + 1)
-                if (np.less_equal(run[0], keep) & np.less_equal(keep, run[-1])).any()
+                np.arange(start, stop + 1, dtype=np.int32)
+                for start, stop in matches
+                if (np.less_equal(start, keep) & np.less_equal(keep, stop)).any()
             ]
         )
         counts[hap] = var_inds.size
         return var_inds
 
     def sparse_matrix(self) -> sparse.csr_matrix:
-        matches_row: sparse.csr_matrix = load_sparse_comp_matches_hybrid_npz(
+        match_matrix = SparseCompositeMatchesNpz(
             *self.target_hap, self.npz_dir, self.shape, self.logger
         )
-        best_matches = self._best_matches(matches_row)
+        best_matches = [
+            match_matrix.get_row_matches(row)[: self.kept_matches]
+            for row in range(self.shape[1])
+        ]
         haps, counts = np.unique(np.hstack(best_matches), return_counts=True)
         best_haps = haps[counts > 1]
         filtered_matches = [_filter_hap_indices(row, best_haps) for row in best_matches]
@@ -121,17 +75,15 @@ class CompositePanelMaskFilter:
             (np.full(indptr[-1], True, dtype=np.bool_), indices, indptr),
             shape=self.shape,
         ).tocsr()
-        del indptr
         counts = np.zeros(self.shape[0], dtype=int)
         indices = np.hstack(
             [
                 self._expand_matches(
-                    matches_row[hap].indices, matrix[hap].indices, hap, counts
+                    match_matrix.get_hap_matches(hap), matrix[hap].indices, hap, counts
                 )
                 for hap in np.unique(indices)
             ]
         )
-        del matches_row
         del matrix
         indptr = np.append([0], np.cumsum(counts))
         return sparse.csr_matrix(
@@ -141,35 +93,6 @@ class CompositePanelMaskFilter:
 
     def haplotype_id_lists(self) -> np.ndarray:
         return self.sparse_matrix().tolil().rows.copy()
-
-
-def run_hmm(
-    chip_sites_n: int,
-    ordered_hap_indices: np.ndarray,
-    distances_cm: np.ndarray,
-    num_hid: int = 9000,
-    est_ne: int = 1000000,
-    pErr: float = 0.0001,
-) -> sparse.csr_matrix:
-    """
-    Runs the forward and backward runs of the forward-backward algorithm,
-        to get probabilities for imputation
-    """
-    nHaps = np.array([len(row) for row in ordered_hap_indices])
-    pRecomb_arr: np.ndarray = pRecomb(distances_cm, num_hid=num_hid, ne=est_ne) / nHaps
-
-    matrix_ = setFwdValues_SPARSE(
-        chip_sites_n, ordered_hap_indices, pRecomb_arr, num_hid=num_hid, pErr=pErr
-    )
-    return setBwdValues_SPARSE(
-        matrix_,
-        chip_sites_n,
-        ordered_hap_indices,
-        pRecomb_arr,
-        nHaps,
-        num_hid=num_hid,
-        pErr=pErr,
-    )
 
 
 def calculate_weights(
@@ -184,7 +107,6 @@ def calculate_weights(
 ) -> None:
     """
     Load pbwt matches from npz and calculate weights for imputation
-    Processing as one chunk (CHUNK_SIZE = chip_sites_n)
     """
     ordered_hap_indices = CompositePanelMaskFilter(
         target_hap, npz_dir, shape, logger
@@ -194,18 +116,13 @@ def calculate_weights(
     cutoff = min(np.percentile(counts, 10), counts.max() - 1)
     best_haps = haps[counts > cutoff]
 
-    weight_matrix = run_hmm(
-        shape[1],
+    HMM(
         [_filter_hap_indices(row, best_haps) for row in ordered_hap_indices],
         chip_cM_coordinates,
-        num_hid=shape[0],
+        output_dir,
+        target_hap,
+        output_breaks,
+        shape,
         est_ne=est_ne,
         pErr=cutoff / shape[1],
-    )
-    del ordered_hap_indices
-
-    for start, stop in output_breaks:
-        sparse.save_npz(
-            output_dir.joinpath(str(start), f"{target_hap[0]}_{target_hap[1]}.npz"),
-            weight_matrix[start:stop, :],
-        )
+    ).run()

--- a/modules/interpolation.py
+++ b/modules/interpolation.py
@@ -107,7 +107,7 @@ class Interpolator:
                 ].toarray()
             ).sum(axis=1)
             / weights.sum(axis=1),
-            dtype=np.float_,
+            dtype=np.float64,
         )
 
     def _interpolate_interval(

--- a/modules/load_data.py
+++ b/modules/load_data.py
@@ -1,21 +1,32 @@
-from typing import List, Tuple
+from typing import Iterable, List, Tuple
 from pathlib import Path
-from warnings import filterwarnings
 from logging import Logger
 
 import pandas as pd
 import numpy as np
-from scipy import sparse
 from numba import njit
+from scipy import sparse
 from tqdm import tqdm
 
-######################################
-#                                    #
-#            GLOBAL DATA             #
-#                                    #
-######################################
+from modules.utils import get_std
 
-filterwarnings("ignore", category=sparse.SparseEfficiencyWarning)
+
+@njit
+def _normalize_freqs(freqs: np.ndarray) -> np.ndarray:
+    """
+    Normalize the results linearly between 0.1 and 1, scaling down
+    reference haplotypes that have less total matches with the test sample
+    """
+    rmin = freqs.min()
+    return ((freqs - rmin) / (freqs.max() - rmin)) * 0.9 + 0.1
+
+
+@njit
+def _calculate_threshold(
+    max_normed: np.ndarray, sd_normed: np.ndarray, std_length: np.ndarray
+) -> np.ndarray:
+    """Calculate minimum normalized length to retain a match"""
+    return max_normed - sd_normed * std_length
 
 
 def load_and_interpolate_genetic_map(
@@ -64,43 +75,106 @@ def load_and_interpolate_genetic_map(
     return chip_cM_coordinates
 
 
-@njit
-def _expand_match(row: Tuple[int]) -> np.ndarray:
-    return np.vstack((np.arange(row[0], sum(row)), np.full(row[1], row[1]))).T
+class SparseCompositeMatchesNpz:
+    """Class for loading and processing pbwt matches"""
 
+    def __init__(
+        self,
+        sample_name: str,
+        hap: int,
+        npz_dir: Path,
+        shape: Tuple[int],
+        logger: Logger,
+    ) -> None:
+        matrix: sparse.csr_matrix = sparse.load_npz(
+            npz_dir.joinpath(f"parallel_haploid_mat_{sample_name}_{hap}.npz")
+        ).tocsr()
+        if matrix.shape != shape:
+            raise IndexError(
+                f"Sparse matrix for {sample_name}_{hap} is the wrong shape. "
+                f"Expected shape: {shape}. Actual shape: {matrix.shape}"
+            )
+        self.n_haps, self.n_var = matrix.shape
+        self.starts = matrix.indices.copy()
+        self.stops = (matrix.indices + matrix.data - 1).copy()
 
-def load_sparse_comp_matches_hybrid_npz(
-    sample_name: str, hap: int, npz_dir: Path, shape: Tuple[int], logger: Logger
-) -> sparse.csr_matrix:
-    npz_path = npz_dir.joinpath(f"parallel_haploid_mat_{sample_name}_{hap}.npz")
-    x: sparse.csr_matrix = sparse.load_npz(npz_path).tocsr()
-    if x.shape != shape:
-        raise IndexError(
-            f"Sparse matrix for {sample_name}_{hap} is the wrong shape. "
-            f"Expected shape: {shape}. Actual shape: {x.shape}"
+        # cache row indices
+        self.row_indices = np.fromiter(
+            [self._get_row_indices(row) for row in range(self.n_var)], dtype=np.ndarray
         )
 
-    indptr = np.append([0], np.cumsum(x.sum(axis=1)))
-    expanded = np.vstack([_expand_match(row) for row in zip(x.indices, x.data)])
-    x = sparse.csr_matrix((expanded[:, 1], expanded[:, 0], indptr), shape=x.shape)
+        # handle variants with no pbwt matches
+        missing = np.array(
+            [idx for idx, row in enumerate(self.row_indices) if row.size == 0]
+        )
+        if missing.size >= 15:
+            logger.warning(
+                f"\nSample {sample_name} haplotype {hap} had no matches at "
+                f"{missing.size} variants"
+            )
+        added_freq = np.zeros((self.n_haps, 1), dtype=np.int32)
+        if missing[0] == 0:
+            # work backwards from first variant with a match
+            start = np.nonzero(np.diff(missing) > 1)[0][0] + 1
+            self.starts[self.starts == start] = 0
+            self.row_indices[:start] = self.row_indices[start]
+            added_freq[
+                np.searchsorted(matrix.indptr, self.row_indices[start], side="right")
+                - 1
+            ] = start
+        else:
+            start = 0
+        # work forwards, extending matches forward
+        for i in missing[start:]:
+            self.stops[self.stops == i - 1] = i
+            self.row_indices[i] = self.row_indices[i - 1]
+            added_freq[
+                np.searchsorted(matrix.indptr, self.row_indices[i - 1], side="right")
+                - 1
+            ] += 1
 
-    # handle variants with no matches
-    missing: np.ndarray = np.where(x.getnnz(axis=0) == 0)[0]
-    if missing.size >= 15:
-        logger.warning(
-            f"\nSample {sample_name} haplotype {hap} had no matches at {missing.size} variants"
+        # normalize data by haplotype frequencies with tmin = 0.1 and tmax = 1
+        normed_freqs = _normalize_freqs(matrix.sum(axis=1).A + added_freq)
+        self.normed: np.ndarray = matrix.multiply(normed_freqs).tocsr().data
+
+        # calculate metrics for each variant
+        avg_len = np.zeros((self.n_var,), dtype=np.float64)
+        sd_normed = np.zeros((self.n_var,), dtype=np.float64)
+        max_normed = np.zeros((self.n_var,), dtype=np.float64)
+        for row in range(self.n_var):
+            avg_len[row] = matrix.data[self.row_indices[row]].mean()
+            row_norm = self.normed[self.row_indices[row]]
+            sd_normed[row] = row_norm.std()
+            max_normed[row] = row_norm.max()
+
+        # calculate minimum threshold to keep a match for each variant
+        self.threshold = _calculate_threshold(
+            max_normed, sd_normed, get_std(avg_len, matrix.data.min(), self.n_var)
         )
 
-    if missing[0] == 0:
-        start = np.where(np.diff(missing) > 1)[0][0] + 1
-        # work backwards from first variant with a match
-        for i in missing[:start][::-1]:
-            x[x[:, i + 1].nonzero()[0], i] = x[:, i + 1].data + 1
-    else:
-        start = 0
+        self.indptr = matrix.indptr
 
-    # work forwards, extending matches forward
-    for i in missing[start:]:
-        x[x[:, i - 1].nonzero()[0], i] = x[:, i - 1].data + 1
+    def _get_row_indices(self, row: int) -> np.ndarray:
+        """
+        Get indices of nonzero values for variant.
+        Indices point to starts, stops, and normed, not haps.
+        """
+        return ((self.starts <= row) * (self.stops >= row)).nonzero()[0]
 
-    return x
+    def get_row_matches(self, row: int) -> np.ndarray:
+        """
+        Find the matches that exceed the threshold in a given row
+        and return in order of best to worst
+        """
+        match_indices = self.row_indices[row][
+            self.normed[self.row_indices[row]] >= self.threshold[row]
+        ]
+        haps = np.searchsorted(self.indptr, match_indices, side="right") - 1
+        return haps[np.argsort(self.normed[match_indices])[::-1]]
+
+    def get_hap_matches(self, hap: int) -> Iterable[Tuple[int]]:
+        """Return tuples with ends of hap matches"""
+        return zip(
+            self.starts[self.indptr[hap] : self.indptr[hap + 1]],
+            self.stops[self.indptr[hap] : self.indptr[hap + 1]],
+        )

--- a/modules/utils.py
+++ b/modules/utils.py
@@ -12,17 +12,15 @@ from tqdm import tqdm
 def get_std(
     avg_length: np.ndarray, min_length: int, max_length: int, a: int = 25
 ) -> np.ndarray:
-    # convert average length into number on x axis
-    rmin = max_length
-    rmax = min_length
-    avg_length = (avg_length - rmin) / (rmax - rmin)
-
-    std_not_normed = a * avg_length ** (a - 1.0)
-
-    rmax_ = a * 1 ** (a - 1.0)
-    tmin_ = 0.2
-    tmax_ = 3
-    return (std_not_normed / rmax_) * (tmax_ - tmin_) + tmin_
+    """
+    Determine how many std devs to keep for each variant. Derived from:
+     std_not_normed = a * avg_length ** (a - 1.0)
+     rmax_ = a * 1 ** (a - 1.0)
+     return (std_not_normed / rmax_) * (tmax_ - tmin_) + tmin_
+    Simplified since a is positive, using tmin = 0.2 and tmax = 3 std devs.
+    """
+    avg_length = (avg_length - max_length) / (min_length - max_length)
+    return avg_length ** (a - 1.0) * 2.8 + 0.2
 
 
 def timestamp() -> str:
@@ -53,7 +51,9 @@ def tqdm_joblib(*args, **kwargs):
 
 def get_version() -> str:
     """Retrieve version from pyproject.toml"""
-    lines = Path(__file__).parents[1].joinpath("pyproject.toml").read_text().splitlines()
+    lines = (
+        Path(__file__).parents[1].joinpath("pyproject.toml").read_text().splitlines()
+    )
     for line in lines:
         if line.startswith("version"):
             return line.split('"')[-2]

--- a/modules/utils.py
+++ b/modules/utils.py
@@ -3,10 +3,12 @@ from contextlib import contextmanager
 from pathlib import Path
 
 import numpy as np
+from numba import njit
 import joblib
 from tqdm import tqdm
 
 
+@njit
 def get_std(
     avg_length: np.ndarray, min_length: int, max_length: int, a: int = 25
 ) -> np.ndarray:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ cachetools
 cyvcf2==0.31.1
 joblib
 numba
-numpy==1.24.4
+numpy
 pandas
 scipy
 tqdm

--- a/selphi.py
+++ b/selphi.py
@@ -66,6 +66,8 @@ def selphi(
     # Load target samples and variants
     vcf_obj = cyvcf2.VCF(targets_path)
     target_samples = vcf_obj.samples
+    if not target_samples:
+        raise IndexError(f"No samples found in target vcf: {targets_path}")
     if ref_panel.variants[0][2] not in ref_panel.ids[0]:
         # hash alleles
         target_markers = np.array(
@@ -89,6 +91,8 @@ def selphi(
             dtype=ref_panel.variant_dtypes,
         )
     del vcf_obj
+    if target_markers.size == 0:
+        raise IndexError(f"No variants found in target vcf: {targets_path}")
     if target_markers[0][0] != ref_panel.chromosome:
         raise KeyError(
             f"Reference panel chromosome {ref_panel.chromosome} does not match "


### PR DESCRIPTION
- Reduced memory usage during haplotype selection
  - Load start and stop points of matches instead of all points in match
  - Cache row indices pointing to sparse matrix indices and data arrays
  - Calculate all row metrics in one pass
  - Produces identical haplotype lists (except for occasional tie breaking during haplotype sorting)
- Reduced memory usage during HMM calculations
  - Load matrix in blocks that will be saved for interpolation, carrying overlapping row to next block
  - Only include haplotypes with at least one match in forward block matrix
  - Cache forward blocks as zstd compressed bytes in memory instead of saving every 30th row and recalculating rows in between
  - **Change: using two probability of recombination arrays**
    - Forward calculations use probability between chip index - 1 and chip index (old version)
    - Backward calculations use probability between chip index + 1 and chip index
  - Results were identical before introducing second recombination probability array
    - Modified backwards calculation reduced imputation errors
- Updated Dockerfile
  - Selphi now compatible with numpy 2.0
  - Using latest version of bcftools and htslib
  - Base is now Ubuntu 22.04
  - Updated python from 3.8 to 3.10
- Added checking of target vcf for samples and genotypes