### PR TITLE
Add numerical stability to HMM weight calculation

### DIFF
--- a/modules/hmm_utils.py
+++ b/modules/hmm_utils.py
@@ -157,10 +157,7 @@ class HMM:
                 )
                 weights[-2, :] = weights[-1, :]
 
-            weight_sums = weights.sum(axis=1, keepdims=True)
-            weight_sums = np.where(weight_sums == 0, 1.0, weight_sums)
-            weights = weights / weight_sums
-            weights = np.round(weights, 8)
+            weights = np.round(weights / weights.sum(axis=1, keepdims=True), 8)
             weights[weights < 1 / (self.matches.size + 1)] = 0
 
             # create sparse matrix of entire reference panel

--- a/modules/hmm_utils.py
+++ b/modules/hmm_utils.py
@@ -157,7 +157,10 @@ class HMM:
                 )
                 weights[-2, :] = weights[-1, :]
 
-            weights = weights / weights.sum(axis=1, keepdims=True)
+            weight_sums = weights.sum(axis=1, keepdims=True)
+            weight_sums = np.where(weight_sums == 0, 1.0, weight_sums)
+            weights = weights / weight_sums
+            weights = np.round(weights, 8)
             weights[weights < 1 / (self.matches.size + 1)] = 0
 
             # create sparse matrix of entire reference panel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "selphi"
-version = "1.5.2"
+version = "1.5.3"
 description = "Genotype imputation using PBWT and haplotype selection"
 authors = ["Adriano De Marino <adriano@selfdecode.com>", "Sandra Bohn <sandra@selfdecode.com>"]
 readme = "README.md"
@@ -15,5 +15,5 @@ requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.commitizen]
-version = "1.5.2"
+version = "1.5.3"
 version_files = ["pyproject.toml:version"]


### PR DESCRIPTION
Add numerical stability to HMM weight calculation, prevent division by zero and round to 8 decimals for consistent results, avoiding micro-variations in high-throughput environments like AWS Fargate in prod-us