### PR TITLE
fix: thread-safe reference-panel chunk cache (KeyError during interpolation)

### DIFF
--- a/modules/sparse_ref_panel.py
+++ b/modules/sparse_ref_panel.py
@@ -46,6 +46,7 @@ from datetime import datetime
 from zipfile import ZipFile, BadZipFile
 from tempfile import TemporaryDirectory
 import concurrent.futures
+import threading
 
 from zstd import compress, uncompress
 import numpy as np
@@ -83,6 +84,7 @@ class SparseReferencePanel:
         self.original_ids: List[str] = self._load_original_ids()
         self.sample_ids: List[str] = self._load_sample_ids()
         self._cache = LRUCache(maxsize=cache_size)
+        self._cache_lock = threading.RLock()
 
     def __len__(self):
         return self.n_variants
@@ -430,7 +432,7 @@ class SparseReferencePanel:
             return np.reshape(chunks_, (self.n_chunks, 3))
         return chunks_
 
-    @cachedmethod(lambda self: self._cache)
+    @cachedmethod(lambda self: self._cache, lock=lambda self: self._cache_lock)
     def _load_haplotypes(self, chunk: int) -> sparse.csc_matrix:
         """Load a sparse matrix from archived npz"""
         with ZipFile(self.filepath, mode="r") as archive:


### PR DESCRIPTION
## Problem

Long imputation runs crash during interpolation with:

```
File ".../cachetools/__init__.py", ... in popitem
    return (key, self.pop(key))
  ...
KeyError: (683,)
```

`SparseReferencePanel._load_haplotypes`
(`modules/sparse_ref_panel.py`) caches panel chunks in a `cachetools.LRUCache`
(`cache_size=2`, hardcoded in `selphi.py`) via `@cachedmethod` with **no lock**.
`LRUCache` is not thread-safe. When the cache is accessed by parallel workers
sharing one panel instance, two evictions race: `popitem()` reads the LRU key,
another worker deletes it, then `self.pop(key)` -> `self[key]` raises `KeyError`.
The `683` is the chunk being loaded, not an out-of-range index. With `maxsize=2`
the cache evicts on almost every access, so long/large runs (e.g. ~1000 samples)
hit it with high probability.

## Fix

Guard the `cachedmethod` with an `RLock`. Only the cache get/set are serialized;
the actual chunk load (zip read + `load_npz`) stays outside the lock, so there is
no meaningful slowdown. Cache size, memory footprint and imputed results are
unchanged.

## Verification

Reproduced on the real module with 16 threads x 4000 accesses, `maxsize=2`:
- lock-less (current `master`): `KeyError((226,))` — same signature as reported.
- with the lock (this PR): 4 consecutive runs, no crash.

Fixes the interpolation `KeyError` reported on eMERGE/UKBB imputation runs.